### PR TITLE
build: add native Apple Silicon DMG pipeline

### DIFF
--- a/.github/workflows/macos-arm64.yml
+++ b/.github/workflows/macos-arm64.yml
@@ -1,0 +1,72 @@
+name: macOS ARM64
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: macos-arm64-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Native Apple Silicon DMG
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: app/go.mod
+          cache-dependency-path: |
+            app/go.sum
+            server/go.sum
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: web/package-lock.json
+      - name: Verify native ARM64 runner
+        run: test "$(uname -m)" = arm64
+      - name: Build and package DMG
+        env:
+          CPA_ORBIT_MAC_ARCH: arm64
+        run: ./app/build-macos.sh
+      - name: Verify application architecture
+        run: test "$(lipo -archs 'app/build/bin/CPA Orbit.app/Contents/MacOS/CPAOrbit')" = arm64
+      - uses: actions/upload-artifact@v4
+        with:
+          name: CPAOrbit-macos-arm64
+          path: |
+            app/build/bin/CPAOrbit-macos-arm64.dmg
+            app/build/bin/CPAOrbit-macos-arm64.zip
+            app/build/bin/CHECKSUMS-SHA256.txt
+          if-no-files-found: error
+
+  release:
+    name: Publish macOS assets
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: CPAOrbit-macos-arm64
+          path: dist
+      - name: Publish release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          if gh release view "$GITHUB_REF_NAME" >/dev/null 2>&1; then
+            gh release upload "$GITHUB_REF_NAME" dist/* --clobber
+          else
+            gh release create "$GITHUB_REF_NAME" dist/* --generate-notes --verify-tag
+          fi

--- a/README.md
+++ b/README.md
@@ -149,6 +149,14 @@ cd CPA_Orbit
 
 The portable executable is written to `app/build/bin/CPAOrbit.exe`. A repository build automatically shares the root `data/` and `k12/` directories with the browser console and starts or reuses all required local services.
 
+### macOS Apple Silicon build
+
+```bash
+CPA_ORBIT_MAC_ARCH=arm64 ./app/build-macos.sh
+```
+
+On an Apple Silicon Mac, this writes a native `CPA Orbit.app`, ZIP, drag-to-install DMG, and SHA-256 checksums to `app/build/bin`. Pull requests and `main` updates build the ARM64 package on a native GitHub Actions runner; `v*` tags publish the package to GitHub Releases.
+
 ## Verification
 
 ```powershell

--- a/app/build-macos.sh
+++ b/app/build-macos.sh
@@ -5,7 +5,7 @@ WAILS_VERSION="v2.13.0"
 APP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$APP_DIR/.." && pwd)"
 
-for command_name in go node npm ditto shasum; do
+for command_name in go node npm ditto hdiutil lipo shasum; do
   if ! command -v "$command_name" >/dev/null 2>&1; then
     printf 'Missing required command: %s\n' "$command_name" >&2
     exit 1
@@ -35,7 +35,7 @@ go run "github.com/wailsapp/wails/v2/cmd/wails@$WAILS_VERSION" build \
   -clean -trimpath -skipbindings -platform "darwin/$arch" -ldflags "-s -w"
 
 output_dir="$APP_DIR/build/bin"
-app_path="$output_dir/CPAOrbit.app"
+app_path="$output_dir/CPA Orbit.app"
 if [[ ! -d "$app_path" ]]; then
   printf 'Expected app bundle was not produced: %s\n' "$app_path" >&2
   exit 1
@@ -45,14 +45,51 @@ if [[ -n "${CPA_ORBIT_CODESIGN_IDENTITY:-}" ]]; then
     --sign "$CPA_ORBIT_CODESIGN_IDENTITY" "$app_path"
 fi
 
+executable_path="$app_path/Contents/MacOS/CPAOrbit"
+if [[ ! -x "$executable_path" ]]; then
+  printf 'Expected app executable was not produced: %s\n' "$executable_path" >&2
+  exit 1
+fi
+executable_archs="$(lipo -archs "$executable_path")"
+case "$arch" in
+  arm64)
+    [[ "$executable_archs" == "arm64" ]] || {
+      printf 'Expected an arm64 executable, found: %s\n' "$executable_archs" >&2
+      exit 1
+    }
+    ;;
+  amd64)
+    [[ "$executable_archs" == "x86_64" ]] || {
+      printf 'Expected an x86_64 executable, found: %s\n' "$executable_archs" >&2
+      exit 1
+    }
+    ;;
+  universal)
+    [[ " $executable_archs " == *" arm64 "* && " $executable_archs " == *" x86_64 "* ]] || {
+      printf 'Expected a universal executable, found: %s\n' "$executable_archs" >&2
+      exit 1
+    }
+    ;;
+esac
+
 cp "$APP_DIR/cpa-orbit.config.example.json" "$output_dir/"
 cp "$REPO_ROOT/LICENSE" "$output_dir/LICENSE.txt"
 cp "$REPO_ROOT/docs/THIRD_PARTY_NOTICES.md" "$output_dir/"
 archive="$output_dir/CPAOrbit-macos-$arch.zip"
-rm -f "$archive"
+dmg="$output_dir/CPAOrbit-macos-$arch.dmg"
+rm -f "$archive" "$dmg"
 ditto -c -k --sequesterRsrc --keepParent "$app_path" "$archive"
+
+dmg_staging_dir="$(mktemp -d "${TMPDIR:-/tmp}/cpa-orbit-dmg.XXXXXX")"
+trap 'rm -rf "$dmg_staging_dir"' EXIT
+ditto "$app_path" "$dmg_staging_dir/CPA Orbit.app"
+ln -s /Applications "$dmg_staging_dir/Applications"
+hdiutil create -volname "CPA Orbit" -srcfolder "$dmg_staging_dir" \
+  -ov -format UDZO "$dmg"
+hdiutil verify "$dmg"
+
 (
   cd "$output_dir"
-  shasum -a 256 "$(basename "$archive")" > CHECKSUMS-SHA256.txt
+  shasum -a 256 "$(basename "$archive")" "$(basename "$dmg")" > CHECKSUMS-SHA256.txt
 )
-printf 'Build complete: %s\n' "$output_dir"
+printf 'Build complete (%s): %s\n' "$executable_archs" "$output_dir"

--- a/docs/development/desktop.md
+++ b/docs/development/desktop.md
@@ -26,7 +26,9 @@ Run on a Mac with Go 1.25+, Node.js/npm, and Xcode Command Line Tools:
 ./app/build-macos.sh
 ```
 
-The script builds the current machine architecture and writes `CPAOrbit.app` plus a distributable ZIP to `app/build/bin`. Set `CPA_ORBIT_MAC_ARCH=universal` to build a universal application. For signing, set `CPA_ORBIT_CODESIGN_IDENTITY` to the signing identity before running the script. Apple notarization is intentionally left to the release environment because it requires private Apple credentials.
+The script builds the current machine architecture and writes `CPA Orbit.app`, a distributable ZIP, a drag-to-install DMG, and `CHECKSUMS-SHA256.txt` to `app/build/bin`. Set `CPA_ORBIT_MAC_ARCH=arm64` for an Apple Silicon-only package or `CPA_ORBIT_MAC_ARCH=universal` for a universal application. The script validates the executable architecture and verifies the generated disk image before completing.
+
+GitHub Actions runs the ARM64 build natively on Apple Silicon for every pull request and `main` update. Tags matching `v*` publish the DMG, ZIP, and checksums to the corresponding GitHub Release. For signing, set `CPA_ORBIT_CODESIGN_IDENTITY` to the signing identity before running the script. Apple notarization is intentionally left to a credentialed release environment because it requires private Apple credentials.
 
 ## One-click services and shared data
 

--- a/docs/zh/development/desktop.md
+++ b/docs/zh/development/desktop.md
@@ -15,4 +15,14 @@ Wails 桌面宿主嵌入生产 Vue 构建，并与浏览器控制台共享同一
 
 产物位于 `app/build/bin/CPAOrbit.exe`。仓库内运行时会启动或复用 Monitor API，并按需发现 CLIProxyAPI。桌面端补充系统托盘、关闭到托盘、原生通知、任务栏提醒与开机启动。
 
-切换到 English 可阅读 macOS、签名、便携目录和环境变量的完整说明。
+## macOS Apple Silicon 构建
+
+在安装 Go 1.25+、Node.js/npm 和 Xcode Command Line Tools 的 Apple Silicon Mac 上运行：
+
+```bash
+CPA_ORBIT_MAC_ARCH=arm64 ./app/build-macos.sh
+```
+
+脚本会在 `app/build/bin` 生成原生 ARM64 的 `CPA Orbit.app`、ZIP、可拖拽安装的 DMG 和 SHA-256 校验文件，并验证应用架构与磁盘映像。GitHub Actions 会在每个 PR 和 `main` 更新时使用原生 ARM64 runner 构建；推送 `v*` 标签后，DMG、ZIP 和校验文件会自动上传到对应 GitHub Release。
+
+如需签名，请设置 `CPA_ORBIT_CODESIGN_IDENTITY`。Apple 公证需要私密开发者凭据，因此保留给具备凭据的发布环境。切换到 English 可阅读便携目录和环境变量的完整说明。


### PR DESCRIPTION
## Summary

- Add a native Apple Silicon GitHub Actions build on the standard ARM64 macOS runner.
- Generate and verify a drag-to-install DMG alongside the existing ZIP.
- Validate the Mach-O architecture and publish DMG, ZIP, and SHA-256 checksums for `v*` tags.
- Fix the existing macOS script's bundle path and executable permission.
- Document local and automated ARM64 packaging in English and Chinese.

## User-visible changes

Apple Silicon users can build or download a native ARM64 DMG without Rosetta. The image contains `CPA Orbit.app` and an `Applications` drag target.

## Technical approach

The repository had a macOS helper script, but CI only exercised the Windows desktop host. The script also expected `CPAOrbit.app` while Wails produces `CPA Orbit.app`, so it stopped after a successful compile and never packaged an artifact. The new workflow builds natively on `macos-14`, uploads build artifacts for every run, and publishes them for version tags.

Closes #9

## Security and privacy impact

- [x] No security or privacy impact

No credentials, signing identities, runtime data, or private assets are included. Signing/notarization remains opt-in for a credentialed release environment.

## Verification

- [ ] Server tests: `cd server && go test ./...` (one pre-existing macOS temporary-path failure in `TestImportAllowsPartialJSONDifferences`; this PR does not modify that package)
- [x] Desktop tests: `cd app && go test ./...`
- [x] Web production build: `cd web && npm run build`
- [x] Native ARM64 Wails build: `CPA_ORBIT_MAC_ARCH=arm64 ./app/build-macos.sh`
- [x] DMG verified with `hdiutil verify` and mounted to inspect `CPA Orbit.app` plus the `Applications` link
- [x] Mach-O architecture verified as `arm64`
- [x] ZIP and DMG SHA-256 checksums verified
- [x] `codesign --verify --deep --strict` passed
- [x] Workflow YAML and `git diff --check` passed

## Documentation and release readiness

- [x] Documentation is updated
- [x] Changelog update is not required for this build-pipeline PR
- [x] ADR is not required; no architecture, persistence, or trust-boundary change
- [x] No credentials, runtime data, logs, account identifiers, or private screenshots are included
- [x] The change is backwards compatible
