### PR TITLE
docs: credit v1.2.1 Apple Silicon contributor

### DIFF
--- a/docs/releases/CHANGELOG.md
+++ b/docs/releases/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable CPA Orbit changes are documented here. Versions follow Semantic Vers
 
 ## [Unreleased]
 
+## [1.2.1] - 2026-07-20
+
+### Added
+
+- Added a native macOS Apple Silicon CI build and published ARM64 DMG and ZIP packages with SHA-256 checksums.
+- Added architecture and disk-image verification to the macOS packaging workflow.
+
+### Fixed
+
+- Corrected the Wails macOS bundle path to use the generated `CPA Orbit.app` name.
+
+### Contributors
+
+- Thanks to [@tomatokoko](https://github.com/tomatokoko) for proposing native Apple Silicon support in [issue #9](https://github.com/2921323707/CPA_Orbit/issues/9).
+
 ## [1.2.0] - 2026-07-20
 
 ### Added

--- a/docs/releases/v1.2.1.md
+++ b/docs/releases/v1.2.1.md
@@ -1,0 +1,23 @@
+# CPA Orbit v1.2.1
+
+**Release title:** CPA Orbit v1.2.1 — Native Apple Silicon Packages
+
+CPA Orbit v1.2.1 adds native macOS Apple Silicon distribution so M1, M2, M3, and later ARM64 Macs can run the desktop application without Rosetta.
+
+## Highlights
+
+- Added a native ARM64 GitHub Actions build on an Apple Silicon runner.
+- Added a drag-to-install DMG alongside the distributable ZIP archive.
+- Added Mach-O architecture validation and DMG verification to the packaging pipeline.
+- Added SHA-256 checksums for both macOS release artifacts.
+- Published `CPAOrbit-macos-arm64.dmg`, `CPAOrbit-macos-arm64.zip`, and `CHECKSUMS-SHA256.txt` with the v1.2.1 release.
+
+## Fixes
+
+- Corrected the macOS bundle path to match the `CPA Orbit.app` name produced by Wails.
+- Verified that the packaged application executable retains its executable permission and ARM64 architecture.
+
+## Contributors
+
+- Thanks to [@tomatokoko](https://github.com/tomatokoko) for proposing native Apple Silicon support in [issue #9](https://github.com/2921323707/CPA_Orbit/issues/9) and helping shape this release.
+

--- a/docs/zh/releases/CHANGELOG.md
+++ b/docs/zh/releases/CHANGELOG.md
@@ -5,6 +5,13 @@ description: CPA Orbit 版本变化摘要。
 
 # 更新日志
 
+## v1.2.1
+
+- 新增原生 macOS Apple Silicon CI 构建，并发布 ARM64 DMG、ZIP 和 SHA-256 校验文件。
+- 在 macOS 打包流程中加入 Mach-O 架构检查和 DMG 验证。
+- 修正 Wails 生成的 `CPA Orbit.app` 应用包路径。
+- 感谢 [@tomatokoko](https://github.com/tomatokoko) 在 [issue #9](https://github.com/2921323707/CPA_Orbit/issues/9) 中提出原生 Apple Silicon 支持需求并推动本次发布。
+
 ## v1.1.0
 
 - 文档默认语言改为英文，并加入对应路由的简体中文切换。


### PR DESCRIPTION
## Summary

- Add dedicated v1.2.1 release notes for the native Apple Silicon packages.
- Record the release in the English and Chinese changelogs.
- Credit @tomatokoko for proposing Apple Silicon support in #9.

## Why

The v1.2.1 release now includes native ARM64 DMG and ZIP assets, but the repository release documentation did not yet record the patch release or its originating community contribution.

## Impact

Documentation only. Runtime behavior and release assets are unchanged.

## Verification

- `git diff --check`
- Verified the commit contains the GitHub-recognized `Co-authored-by` trailer for @tomatokoko.